### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "^4.21.1",
-    "express-session": "^1.18.1"
+    "express-session": "^1.18.1",
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -2,7 +2,7 @@ import express from 'express';
 import session from 'express-session';
 import path from 'path';
 import { fileURLToPath } from 'url';
-
+import rateLimit from 'express-rate-limit';
 // const cors = require('cors');
 
 const PORT = process.env.PORT || 8080;
@@ -13,6 +13,13 @@ const clientPath = path.join(__dirname, clientFolder);
 const clientIndex = path.join(clientPath, 'index.html');
 
 const app = express();
+
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
 app.use(express.json());
 
@@ -72,7 +79,7 @@ app.get('/logout', (req, res) => {
 
 app.use(express.static(clientPath));
 
-app.get('*', (req, res) => {
+app.get('*', limiter, (req, res) => {
 	res.sendFile(clientIndex);
 });
 


### PR DESCRIPTION
Fixes [https://github.com/hikumar01/full-stack-server/security/code-scanning/2](https://github.com/hikumar01/full-stack-server/security/code-scanning/2)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server/server.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum 100 requests per 15 minutes).
4. Apply the rate limiter to the route handler that serves the static file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
